### PR TITLE
fix(callbacks): fixed upload on nil local file

### DIFF
--- a/app/models/apress/amazon_assets/concerns/base_asset.rb
+++ b/app/models/apress/amazon_assets/concerns/base_asset.rb
@@ -124,7 +124,7 @@ module Apress
         #
         # Returns nothing.
         def store_need_upload
-          @need_upload = local_updated_at_changed?
+          @need_upload = local_updated_at_changed? && local?
           nil
         end
 

--- a/spec/models/apress/amazon_assets/concerns/base_asset_shared_examples.rb
+++ b/spec/models/apress/amazon_assets/concerns/base_asset_shared_examples.rb
@@ -194,6 +194,13 @@ shared_examples_for 'base asset' do |factory_name|
         And  { expect(upload_job).to have_received(:enqueue).with(subject.id, described_class.name) }
       end
 
+      context 'when local file changed to nil' do
+        before { subject.update_attributes! local: nil }
+
+        Then { expect(subject).to be_persisted }
+        And  { expect(upload_job).to_not have_received(:enqueue) }
+      end
+
       context 'when local file not changed' do
         before { subject.save! }
 


### PR DESCRIPTION
https://jira.railsc.ru/browse/PC4-15472

Что происходило:
1) Загружаем файл, 
2) Сохраняем запускается джоба переноса файла на амазон
3) Каждый день запускается [таска](https://github.com/abak-press/apress-amazon_assets/blob/master/lib/apress/amazon_assets/tasks.rake#L11) по удалению файлов локально ставя nil и сохраняя, тем самым запуская [callback](https://github.com/abak-press/apress-amazon_assets/blob/master/app/models/apress/amazon_assets/concerns/base_asset.rb#L29) по переносу фаилов на амазон
4) Новая джоба видя что файла нет, затирает файл на амазоне
5)....
6) ПОТРАЧЕНО
