### PR TITLE
fix: отключение проверки на подмену расширения

### DIFF
--- a/app/models/apress/amazon_assets/private_asset.rb
+++ b/app/models/apress/amazon_assets/private_asset.rb
@@ -10,7 +10,8 @@ module Apress
                         :path => ":rails_root/public/system/assets/:id_partition/:basename.:extension",
                         :url => "#{ActionController::Base.asset_host}/system/assets/:id_partition/:basename.:extension",
                         :use_timestamp => false,
-                        :filename_cleaner => ->(filename) { filename }
+                        :filename_cleaner => ->(filename) { filename },
+                        :validate_media_type => false
 
       has_attached_file :remote,
                         :storage => :s3,
@@ -21,7 +22,8 @@ module Apress
                         :path => "assets/:id_partition/:basename.:extension",
                         :url => "https://s3.amazonaws.com/#{S3_BUCKET}/assets/:id_partition/:basename.:extension",
                         :use_timestamp => false,
-                        :filename_cleaner => ->(filename) { filename }
+                        :filename_cleaner => ->(filename) { filename },
+                        :validate_media_type => false
 
       include ::Apress::AmazonAssets::Concerns::BaseAsset
     end

--- a/app/models/apress/amazon_assets/public_asset.rb
+++ b/app/models/apress/amazon_assets/public_asset.rb
@@ -10,7 +10,8 @@ module Apress
                         :path => ":rails_root/public/system/public_assets/:id_partition/:basename.:extension",
                         :url => "#{ActionController::Base.asset_host}/system/public_assets/:id_partition/:basename.:extension",
                         :use_timestamp => false,
-                        :filename_cleaner => ->(filename) { filename }
+                        :filename_cleaner => ->(filename) { filename },
+                        :validate_media_type => false
 
       has_attached_file :remote,
                         :storage => :s3,
@@ -21,7 +22,8 @@ module Apress
                         :path => "public_assets/:id_partition/:basename.:extension",
                         :url => "https://s3.amazonaws.com/#{S3_BUCKET}/public_assets/:id_partition/:basename.:extension",
                         :use_timestamp => false,
-                        :filename_cleaner => ->(filename) { filename }
+                        :filename_cleaner => ->(filename) { filename },
+                        :validate_media_type => false
 
       include ::Apress::AmazonAssets::Concerns::BaseAsset
     end


### PR DESCRIPTION
https://jira.railsc.ru/browse/SERVICES-877

Опция добавилась в пэперклипе новом, проверяет что расширение соответсвует mime-типу. Это плохо работает т.к. в некотрых системах файлы типа yml имеют тип как application/x-yaml, а под виндой как application/octet-stream.
